### PR TITLE
Update bulk competitor adding (Issue #1)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,17 +104,27 @@ const App = () => {
   };
 
   const addBulkCompetitors = () => {
+    // Split the bulk names by new lines and map each line to a competitor object
     const newCompetitors = bulkNames.split(/\n+/).map((n) => {
-      const nameWcaAndReg = n.split(/\s*>\s*/);
+
+      // Split the line by '-' to separate name, WCA ID, and group
+      const nameWcaRegAndGroup = n.split(/\s*-\s*/);
+      const group = nameWcaRegAndGroup[1] || 0;
+
+      // Split the name and WCA ID by '>' to separate registration ID
+      const nameWcaAndReg = nameWcaRegAndGroup[0].split(/\s*>\s*/);
       const regId = nameWcaAndReg[1] || 0;
 
+      // Split the name and WCA ID by '|' to separate WCA ID
       const nameAndId = nameWcaAndReg[0].split(/\s*\|\s*/);
       const wcaId = nameAndId[1] || NEW_COMPETITOR;
-      return { name: nameAndId[0], wcaId, group: 0, regId } as Competitor;
+      return { name: nameAndId[0], wcaId, group, regId } as Competitor;
     });
+
     if (competitors.length === currentCompetitorIdx) {
       setCurrentCompetitorIdx((curr) => curr + newCompetitors.length);
     }
+
     setCompetitors((competitors) => [...competitors, ...newCompetitors]);
     setBulkNames("");
     setShowBulkEntry(false);
@@ -571,6 +581,9 @@ const App = () => {
             use the format <code>name | wca_id</code>. To include registration
             IDs, use the format <code>name &gt; reg_id</code> or{" "}
             <code>name | wca_id &gt; reg_id</code>.
+            
+            To include groups, add the group number at the end separated by
+            a dash, e.g. <code>- group</code>.
           </FormLabel>
           <FormControl
             as="textarea"


### PR DESCRIPTION
The bulk competitors adding feature allow for the group to be bulk added along with each individual competitor.
Also changes the modal to account for the new feature.